### PR TITLE
Add iNet-97F Rev.2 to the project.

### DIFF
--- a/board/allwinner/inet97f-ii/Makefile
+++ b/board/allwinner/inet97f-ii/Makefile
@@ -1,0 +1,50 @@
+#
+# (C) Copyright 2000-2003
+# Wolfgang Denk, DENX Software Engineering, wd@denx.de.
+#
+# See file CREDITS for list of people who contributed to this
+# project.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307 USA
+#
+
+
+include $(TOPDIR)/config.mk
+
+LIB	= $(obj)lib$(BOARD).o
+
+COBJS	:= board.o dram.o
+
+SRCS	:= $(COBJS:.o=.c)
+OBJS	:= $(addprefix $(obj),$(COBJS))
+
+$(LIB):	$(obj).depend $(OBJS)
+	$(call cmd_link_o_target, $(OBJS))
+
+clean:
+	rm -f $(OBJS)
+
+distclean:	clean
+	rm -f $(LIB) core *.bak $(obj).depend
+
+#########################################################################
+
+# defines $(obj).depend target
+include $(SRCTREE)/rules.mk
+
+sinclude $(obj).depend
+
+#########################################################################

--- a/board/allwinner/inet97f-ii/board.c
+++ b/board/allwinner/inet97f-ii/board.c
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2007-2011
+ * Allwinner Technology Co., Ltd. <www.allwinnertech.com>
+ * Tom Cubie <tangliang@allwinnertech.com>
+ *
+ * Some board init for the Allwinner A10-evb board.
+ *
+ * See file CREDITS for list of people who contributed to this
+ * project.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+
+#include <common.h>
+
+#ifdef CONFIG_DISPLAY_BOARDINFO
+int checkboard(void) {
+
+	puts("Board: iNet-97f Rev. 2\n");
+	return 0;
+}
+#endif

--- a/board/allwinner/inet97f-ii/dram.c
+++ b/board/allwinner/inet97f-ii/dram.c
@@ -1,0 +1,31 @@
+/* this file is generated, don't edit it yourself */
+
+#include <common.h>
+#include <asm/arch/dram.h>
+
+static struct dram_para dram_para = {
+	.clock = 408,
+	.type = 3,
+	.rank_num = 1,
+	.density = 2048,
+	.io_width = 16,
+	.bus_width = 32,
+	.cas = 6,
+	.zq = 0x7b,
+	.odt_en = 0,
+	.size = 512,
+	.tpr0 = 0x30926692,
+	.tpr1 = 0x1090,
+	.tpr2 = 0x1a0c8,
+	.tpr3 = 0,
+	.tpr4 = 0,
+	.tpr5 = 0,
+	.emr1 = 0x4,
+	.emr2 = 0,
+	.emr3 = 0,
+};
+
+int sunxi_dram_init(void)
+{
+	return DRAMC_init(&dram_para);
+}

--- a/boards.cfg
+++ b/boards.cfg
@@ -294,6 +294,7 @@ gooseberry_a721              arm         armv7       gooseberry_a721           a
 hackberry                    arm         armv7       hackberry           allwinner      sunxi       sun4i:SPL
 h6                           arm         armv7       h6                  allwinner      sunxi       sun4i:SPL
 mini-x                       arm         armv7       mini-x              allwinner      sunxi       sun4i:SPL
+inet97f-ii                   arm         armv7       inet97f-ii          allwinner      sunxi       sun4i:SPL
 kzm9g                        arm         armv7       kzm9g               kmc            rmobile
 armadillo-800eva             arm         armv7       armadillo-800eva    atmark-techno  rmobile
 zynq                         arm         armv7       zynq                xilinx         zynq


### PR DESCRIPTION
U-Boot support for iNet 97F Rev.2 board.
