### PR TITLE
Sunxi current marsboard a20

### DIFF
--- a/arch/arm/cpu/armv7/sunxi/board.c
+++ b/arch/arm/cpu/armv7/sunxi/board.c
@@ -55,7 +55,7 @@ u32 spl_boot_device(void)
 	return BOOT_DEVICE_MMC1;
 }
 
-/* No confiration data available in SPL yet. Hardcode bootmode */
+/* No confirmation data available in SPL yet. Hardcode bootmode */
 u32 spl_boot_mode(void)
 {
 	return MMCSD_MODE_RAW;

--- a/board/sunxi/Makefile
+++ b/board/sunxi/Makefile
@@ -44,6 +44,7 @@ COBJS-$(CONFIG_COBY_MID7042)	+= dram_sun4i_408_1024_iow16.o
 COBJS-$(CONFIG_COBY_MID8042)	+= dram_sun4i_360_1024_iow16.o
 COBJS-$(CONFIG_COBY_MID9742)	+= dram_sun4i_408_1024_iow16.o
 COBJS-$(CONFIG_MARSBOARD_A10)	+= dram_sun4i_360_1024_iow16.o
+COBJS-$(CONFIG_MARSBOARD_A20)	+= dram_sun4i_360_1024_iow16.o
 COBJS-$(CONFIG_CUBIEBOARD)	+= dram_cubieboard.o
 COBJS-$(CONFIG_CUBIEBOARD_512)	+= dram_cubieboard_512.o
 COBJS-$(CONFIG_CUBIEBOARD2)	+= dram_cubieboard2.o

--- a/boards.cfg
+++ b/boards.cfg
@@ -351,6 +351,7 @@ Coby_MID7042                 arm         armv7       sunxi               -      
 Coby_MID8042                 arm         armv7       sunxi               -              sunxi       sun4i:COBY_MID8042,SPL
 Coby_MID9742                 arm         armv7       sunxi               -              sunxi       sun4i:COBY_MID9742,SPL
 Marsboard_A10                arm         armv7       sunxi               -              sunxi       sun4i:MARSBOARD_A10,SPL,SUNXI_EMAC,NO_AXP
+Marsboard_A20                arm         armv7       sunxi               -              sunxi       sun7i:MARSBOARD_A20,SPL,SUNXI_EMAC,NO_AXP
 Cubieboard                   arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_FEL               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL_FEL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_512               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD_512,SPL,SUNXI_EMAC,STATUSLED=244

--- a/common/cmd_elf.c
+++ b/common/cmd_elf.c
@@ -35,8 +35,8 @@ unsigned long do_bootelf_exec(ulong (*entry)(int, char * const[]),
 	unsigned long ret;
 
 	/*
-	 * QNX images require the data cache is disabled.
-	 * Data cache is already flushed, so just turn it off.
+	 * QNX and other kernels require the data cache is disabled.  Data cache
+	 * is already flushed, so just turn it off.
 	 */
 	int dcache = dcache_status();
 	if (dcache)
@@ -57,7 +57,7 @@ unsigned long do_bootelf_exec(ulong (*entry)(int, char * const[]),
 /* ======================================================================
  * Determine if a valid ELF image exists at the given memory location.
  * First looks at the ELF header magic field, the makes sure that it is
- * executable and makes sure that it is for a PowerPC.
+ * executable and makes sure that it is for a valid architecture.
  * ====================================================================== */
 int valid_elf_image(unsigned long addr)
 {
@@ -76,8 +76,13 @@ int valid_elf_image(unsigned long addr)
 		printf("## Not a 32-bit elf image at address 0x%08lx\n", addr);
 		return 0;
 	}
-
-#if 0
+#if defined(CONFIG_ARM)
+	if (ehdr->e_machine != EM_ARM) {
+		printf("## Not an ARM elf image at address 0x%08lx\n", addr);
+		return 0;
+	}
+#endif
+#if defined(CONFIG_PPC)
 	if (ehdr->e_machine != EM_PPC) {
 		printf("## Not a PowerPC elf image at address 0x%08lx\n", addr);
 		return 0;

--- a/include/configs/sun4i.h
+++ b/include/configs/sun4i.h
@@ -30,7 +30,7 @@
  */
 #define CONFIG_SUN4I		/* sun4i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun4i#"
+#define CONFIG_SYS_PROMPT		"sun4i# "
 #define CONFIG_MACH_TYPE		4104
 
 /*

--- a/include/configs/sun5i.h
+++ b/include/configs/sun5i.h
@@ -30,7 +30,7 @@
  */
 #define CONFIG_SUN5I		/* sun5i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun5i#"
+#define CONFIG_SYS_PROMPT		"sun5i# "
 #define CONFIG_MACH_TYPE		4138
 
 /*

--- a/include/configs/sun7i.h
+++ b/include/configs/sun7i.h
@@ -31,7 +31,7 @@
  */
 #define CONFIG_SUN7I		/* sun7i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun7i#"
+#define CONFIG_SYS_PROMPT		"sun7i# "
 #define CONFIG_MACH_TYPE		4283
 
 /*

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -37,6 +37,7 @@
 
 #include <asm/arch/cpu.h>	/* get chip and board defs */
 
+/* Put u-boot at 160MB from start of SDRAM */
 #define CONFIG_SYS_TEXT_BASE		0x4a000000
 
 /*
@@ -188,6 +189,7 @@
 	"extraargs=\0" \
 	"loglevel=8\0" \
 	"scriptaddr=0x44000000\0" \
+	"loadaddr=0x4b000000\0" \
 	"device=mmc\0" \
 	"partition=0:1\0" \
 	"setargs=" \
@@ -224,19 +226,19 @@
 	    " && " \
 	    "ext2load $device $partition 0x43000000 ${bootpath}script.bin" \
 	    " && " \
-	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
+	    "ext2load $device $partition ${loadaddr} ${bootpath}${kernel}" \
 	  ";then true; elif " \
 	    "bootpath=/" \
 	    " && " \
 	    "fatload $device $partition 0x43000000 script.bin" \
 	    " && " \
-	    "fatload $device $partition 0x48000000 ${kernel}" \
+	    "fatload $device $partition ${loadaddr} ${kernel}" \
 	  ";then true; elif " \
 	    "bootpath=/" \
 	    " && " \
 	    "ext2load $device $partition 0x43000000 ${bootpath}script.bin" \
 	    " && " \
-	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
+	    "ext2load $device $partition ${loadaddr} ${bootpath}${kernel}" \
 	  ";then true; else "\
 	    "false" \
 	  ";fi" \
@@ -248,7 +250,7 @@
 	  " && " \
 	  RESET_WATCHDOG \
 	  " && " \
-	  "bootm 0x48000000" \
+	  "bootm ${loadaddr}" \
 	  "\0" \
 	"boot_ram=" \
 	  "saved_stdout=$stdout;setenv stdout nc;"\
@@ -277,7 +279,6 @@
 #define CONFIG_FAT_WRITE	/* enable write access */
 #define CONFIG_CMD_EXT2		/* with this we can access ext2 bootfs */
 #define CONFIG_CMD_EXT4		/* with this we can access ext4 bootfs */
-#define CONFIG_CMD_ZFS		/* with this we can access ZFS bootfs */
 
 #define CONFIG_SPL_FRAMEWORK
 #define CONFIG_SPL_LIBCOMMON_SUPPORT
@@ -423,6 +424,7 @@
 #define CONFIG_BOOTP_MAY_FAIL
 #define CONFIG_BOOTP_SERVERIP
 #define CONFIG_BOOTP_DHCP_REQUEST_DELAY		50000
+#define CONFIG_CMD_ELF
 #endif
 
 #if !defined CONFIG_ENV_IS_IN_MMC && \

--- a/tools/mksunxiboot.README
+++ b/tools/mksunxiboot.README
@@ -1,4 +1,4 @@
-This program make a arm binary file can be loaded by Allwinner A10 and releated
+This program make a arm binary file can be loaded by Allwinner A10 and related
 chips from storage media such as nand and mmc.
 
 More information about A10 boot, please refer to


### PR DESCRIPTION
This adds support for the Marsboard A20 version.

It also includes some miscellaneous fixes:
- Add ELF loading support when networking is selected
- Cleanup hacks in cmd_elf.c
- Make default prompts a little cleaner
- Set and change the default loadaddr to support loading large images
- Remove ZFS filesystem - It's not very common, if you really need it, I suggest adding it to the boards.cfg or edit .config manually
- minor typo fixes
