### PR TITLE
Sunxi current a20 secondary init

### DIFF
--- a/arch/arm/cpu/armv7/sunxi/Makefile
+++ b/arch/arm/cpu/armv7/sunxi/Makefile
@@ -39,6 +39,13 @@ COBJS	+= watchdog.o
 ifdef DEBUG
 COBJS	+= early_print.o
 endif
+ifdef CONFIG_BOARD_POSTCLK_INIT
+COBJS	+= postclk_init.o
+endif
+ifdef CONFIG_SYS_SECONDARY_ON
+COBJS	+= secondary_init.o
+COBJS	+= smp.o
+endif
 
 ifndef CONFIG_SPL_BUILD
 COBJS	+= key.o

--- a/arch/arm/cpu/armv7/sunxi/board.c
+++ b/arch/arm/cpu/armv7/sunxi/board.c
@@ -55,7 +55,7 @@ u32 spl_boot_device(void)
 	return BOOT_DEVICE_MMC1;
 }
 
-/* No confiration data available in SPL yet. Hardcode bootmode */
+/* No confirmation data available in SPL yet. Hardcode bootmode */
 u32 spl_boot_mode(void)
 {
 	return MMCSD_MODE_RAW;

--- a/arch/arm/cpu/armv7/sunxi/postclk_init.c
+++ b/arch/arm/cpu/armv7/sunxi/postclk_init.c
@@ -1,8 +1,6 @@
 /*
- * (C) Copyright 2012-2013 Henrik Nordstrom <henrik@henriknordstrom.net>
- * (C) Copyright 2013 Luke Kenneth Casson Leighton <lkcl@lkcl.net>
- *
- * Configuration settings for the Allwinner A20 (sun7i) CPU
+ * (C) Copyright 2013
+ * Carl van Schaik <carl@ok-labs.com>
  *
  * See file CREDITS for list of people who contributed to this
  * project.
@@ -14,7 +12,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -23,24 +21,13 @@
  * MA 02111-1307 USA
  */
 
-#ifndef __CONFIG_H
-#define __CONFIG_H
+#include <common.h>
 
-/*
- * A20 specific configuration
- */
-#define CONFIG_SUN7I		/* sun7i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun7i# "
-#define CONFIG_MACH_TYPE		4283
-
+int board_postclk_init(void)
+{
 #if defined(CONFIG_SYS_SECONDARY_ON)
-#define CONFIG_BOARD_POSTCLK_INIT 1
+	startup_secondaries();
 #endif
-
-/*
- * Include common sunxi configuration where most the settings are
- */
-#include <configs/sunxi-common.h>
-
-#endif /* __CONFIG_H */
+	return 0;
+}

--- a/arch/arm/cpu/armv7/sunxi/secondary_init.S
+++ b/arch/arm/cpu/armv7/sunxi/secondary_init.S
@@ -1,8 +1,9 @@
 /*
- * (C) Copyright 2012-2013 Henrik Nordstrom <henrik@henriknordstrom.net>
- * (C) Copyright 2013 Luke Kenneth Casson Leighton <lkcl@lkcl.net>
+ * A lowlevel_init function that sets up the stack to call a C function to
+ * perform further init.
  *
- * Configuration settings for the Allwinner A20 (sun7i) CPU
+ * (C) Copyright 2013
+ * Carl van Schaik <carl@ok-labs.com>
  *
  * See file CREDITS for list of people who contributed to this
  * project.
@@ -14,7 +15,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -23,24 +24,25 @@
  * MA 02111-1307 USA
  */
 
-#ifndef __CONFIG_H
-#define __CONFIG_H
+#include <asm-offsets.h>
+#include <config.h>
+#include <linux/linkage.h>
 
-/*
- * A20 specific configuration
- */
-#define CONFIG_SUN7I		/* sun7i SoC generation */
+ENTRY(secondary_init)
+	/* Get cpu number : r5 */
+	mrc	p15, 0, r5, c0, c0, 5
+	and	r5, r5, #0xff
 
-#define CONFIG_SYS_PROMPT		"sun7i# "
-#define CONFIG_MACH_TYPE		4283
+	/*
+	 * Setup a secondary stack, each core gets 128 bytes.
+	 */
+	ldr	sp, =secondary_stack
+	mov	r0, #0x80
+	add	sp, sp, r0, lsl r5
 
-#if defined(CONFIG_SYS_SECONDARY_ON)
-#define CONFIG_BOARD_POSTCLK_INIT 1
-#endif
+	/*
+	 * Jump to C
+	 */
+	bl	secondary_start
+ENDPROC(secondary_init)
 
-/*
- * Include common sunxi configuration where most the settings are
- */
-#include <configs/sunxi-common.h>
-
-#endif /* __CONFIG_H */

--- a/arch/arm/cpu/armv7/sunxi/smp.c
+++ b/arch/arm/cpu/armv7/sunxi/smp.c
@@ -23,6 +23,7 @@
 
 #include <common.h>
 #include <asm/io.h>
+#include <asm/arch/smp.h>
 #include <asm/arch/cpucfg.h>
 
 /* Right now we assume only a single secondary as in sun7i */
@@ -31,9 +32,6 @@
 #else
 #error unsupported SoC
 #endif
-
-/* Assembly entry point */
-extern void secondary_init(void);
 
 static void secondary_pen(void)
 {

--- a/arch/arm/cpu/armv7/sunxi/smp.c
+++ b/arch/arm/cpu/armv7/sunxi/smp.c
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright 2013
+ * Carl van Schaik <carl@ok-labs.com>
+ *
+ * See file CREDITS for list of people who contributed to this
+ * project.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+
+#include <common.h>
+#include <asm/io.h>
+#include <asm/arch/cpucfg.h>
+
+/* Right now we assume only a single secondary as in sun7i */
+#if defined(CONFIG_SUN7I)
+#define NUM_CORES 2
+#else
+#error unsupported SoC
+#endif
+
+/* Assembly entry point */
+extern void secondary_init(void);
+
+static void secondary_pen(void)
+{
+	while (1) {
+		__asm__ __volatile__(
+			"wfi"
+		);
+	};
+}
+
+u32 secondary_stack[32*(NUM_CORES-1)];
+
+void secondary_start(void)
+{
+    secondary_pen();
+}
+
+/* Power on secondaries */
+void startup_secondaries(void)
+{
+	int i;
+	volatile struct sunxi_cpucfg *cpucfg =
+			(struct sunxi_cpucfg *)SUNXI_CPUCFG_BASE;
+
+	cpucfg->boot_addr = (u32)secondary_init;
+
+	for (i = 1; i < NUM_CORES; i++) {
+		/* Assert CPU reset just in case */
+		cpucfg->cpu[i].reset_ctrl = CPU_RESET_SET;
+		/* Ensure CPU reset also invalidates L1 caches */
+		cpucfg->general_ctrl &= ~GENERAL_CTRL_NO_L1_RESET_CPU(i);
+		/* Lock CPU */
+		cpucfg->debug1_ctrl &= ~(1 << i);
+
+		/* Ramp up power to CPU1 */
+		assert(i == 1);
+		u32 j = 0xff;
+		do {
+			cpucfg->cpu1_power_clamp = j;
+			j = j >> 1;
+		} while (j != 0);
+
+		udelay(10*1000); /* 10ms */
+
+		cpucfg->cpu1_power_off &= ~1;
+		/* Release CPU reset */
+		cpucfg->cpu[i].reset_ctrl = CPU_RESET_CLEAR;
+
+		/* Unlock CPU */
+		cpucfg->debug1_ctrl |= (1 << i);
+
+		printf("Secondary CPU%d power-on\n", i);
+	}
+}

--- a/arch/arm/cpu/armv7/sunxi/smp.c
+++ b/arch/arm/cpu/armv7/sunxi/smp.c
@@ -75,10 +75,10 @@ void startup_secondaries(void)
 
 		/* Ramp up power to CPU1 */
 		assert(i == 1);
-		u32 j = 0xff;
+		u32 j = 0xff << 1;
 		do {
-			cpucfg->cpu1_power_clamp = j;
 			j = j >> 1;
+			cpucfg->cpu1_power_clamp = j;
 		} while (j != 0);
 
 		udelay(10*1000); /* 10ms */

--- a/arch/arm/cpu/armv7/sunxi/smp.c
+++ b/arch/arm/cpu/armv7/sunxi/smp.c
@@ -37,9 +37,16 @@ extern void secondary_init(void);
 
 static void secondary_pen(void)
 {
+	volatile struct sunxi_cpucfg *cpucfg =
+			(struct sunxi_cpucfg *)SUNXI_CPUCFG_BASE;
+
 	while (1) {
+		__asm__ __volatile__("wfe");
+
 		__asm__ __volatile__(
-			"wfi"
+			"mov	r14, %0	    \n"
+			"bx	r14	    \n"
+			: : "r" (cpucfg->boot_addr)
 		);
 	};
 }
@@ -48,7 +55,7 @@ u32 secondary_stack[32*(NUM_CORES-1)];
 
 void secondary_start(void)
 {
-    secondary_pen();
+	secondary_pen();
 }
 
 /* Power on secondaries */

--- a/arch/arm/include/asm/arch-sunxi/cpu.h
+++ b/arch/arm/include/asm/arch-sunxi/cpu.h
@@ -86,6 +86,7 @@
 
 #define SUNXI_TP_BASE			0x01c25000
 #define SUNXI_PMU_BASE			0x01c25400
+#define SUNXI_CPUCFG_BASE		0x01c25c00	/* sun7i only ? */
 
 #define SUNXI_UART0_BASE		0x01c28000
 #define SUNXI_UART1_BASE		0x01c28400

--- a/arch/arm/include/asm/arch-sunxi/cpucfg.h
+++ b/arch/arm/include/asm/arch-sunxi/cpucfg.h
@@ -1,0 +1,71 @@
+/*
+ * (C) Copyright 2013
+ * Carl van Schaik <carl@ok-labs.com>
+ *
+ * CPU configuration registers for the sun7i (A20).
+ *
+ * See file CREDITS for list of people who contributed to this
+ * project.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+
+#ifndef _SUNXI_CPUCFG_H_
+#define _SUNXI_CPUCFG_H_
+
+#ifndef __ASSEMBLY__
+
+struct sunxi_cpu_ctrl {
+	u32 reset_ctrl;
+	u32 cpu_ctrl;
+	u32 status;
+	u32 _res[13];
+};
+
+#define CPU_RESET_SET	0
+#define CPU_RESET_CLEAR	3
+
+#define CPU_STATUS_SMP	(1 << 0)
+#define CPU_STATUS_WFE	(1 << 1)
+#define CPU_STATUS_WFI	(1 << 2)
+
+struct sunxi_cpucfg {
+	u32 _res1[16];			/* 0x000 */
+	struct sunxi_cpu_ctrl cpu[2];	/* 0x040 */
+	u32 _res2[48];			/* 0x0c0 */
+	u32 _res3;			/* 0x180 */
+	u32 general_ctrl;		/* 0x184 */
+	u32 _res4[2];			/* 0x188 */
+	u32 event_input;		/* 0x190 */
+	u32 _res5[4];			/* 0x194 */
+	u32 boot_addr;			/* 0x1a4 - also known as PRIVATE_REG */
+	u32 _res6[2];			/* 0x1a8 */
+	u32 cpu1_power_clamp;		/* 0x1b0 */
+	u32 cpu1_power_off;		/* 0x1b4 */
+	u32 _res7[10];			/* 0x1b8 */
+	u32 debug0_ctrl;		/* 0x1e0 */
+	u32 debug1_ctrl;		/* 0x1e4 */
+};
+
+#define GENERAL_CTRL_NO_L1_RESET_CPU(x)	(1UL << (x))
+#define GENERAL_CTRL_NO_L2_AUTO_RESET	(1UL << 4)
+#define GENERAL_CTRL_L2_RESET_SET	(0UL << 5)
+#define GENERAL_CTRL_L2_RESET_CLEAR	(1UL << 5)
+#define GENERAL_CTRL_CFGSDISABLE	(1UL << 8)
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* _SUNXI_CPUCFG_H_ */

--- a/arch/arm/include/asm/arch-sunxi/smp.h
+++ b/arch/arm/include/asm/arch-sunxi/smp.h
@@ -2,6 +2,8 @@
  * (C) Copyright 2013
  * Carl van Schaik <carl@ok-labs.com>
  *
+ * CPU configuration registers for the sun7i (A20).
+ *
  * See file CREDITS for list of people who contributed to this
  * project.
  *
@@ -21,16 +23,16 @@
  * MA 02111-1307 USA
  */
 
-#include <common.h>
-#if defined(CONFIG_SYS_SECONDARY_ON)
-#include <asm/arch/smp.h>
-#endif
+#ifndef _SUNXI_SMP_H_
+#define _SUNXI_SMP_H_
 
+#ifndef __ASSEMBLY__
 
-int board_postclk_init(void)
-{
-#if defined(CONFIG_SYS_SECONDARY_ON)
-	startup_secondaries();
-#endif
-	return 0;
-}
+void startup_secondaries(void);
+
+/* Assembly entry point */
+extern void secondary_init(void);
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* _SUNXI_SMP_H_ */

--- a/board/sunxi/Makefile
+++ b/board/sunxi/Makefile
@@ -44,6 +44,7 @@ COBJS-$(CONFIG_COBY_MID7042)	+= dram_sun4i_408_1024_iow16.o
 COBJS-$(CONFIG_COBY_MID8042)	+= dram_sun4i_360_1024_iow16.o
 COBJS-$(CONFIG_COBY_MID9742)	+= dram_sun4i_408_1024_iow16.o
 COBJS-$(CONFIG_MARSBOARD_A10)	+= dram_sun4i_360_1024_iow16.o
+COBJS-$(CONFIG_MARSBOARD_A20)	+= dram_sun4i_360_1024_iow16.o
 COBJS-$(CONFIG_CUBIEBOARD)	+= dram_cubieboard.o
 COBJS-$(CONFIG_CUBIEBOARD_512)	+= dram_cubieboard_512.o
 COBJS-$(CONFIG_CUBIEBOARD2)	+= dram_cubieboard2.o

--- a/boards.cfg
+++ b/boards.cfg
@@ -352,6 +352,7 @@ Coby_MID8042                 arm         armv7       sunxi               -      
 Coby_MID9742                 arm         armv7       sunxi               -              sunxi       sun4i:COBY_MID9742,SPL
 Marsboard_A10                arm         armv7       sunxi               -              sunxi       sun4i:MARSBOARD_A10,SPL,SUNXI_EMAC,NO_AXP
 Marsboard_A20                arm         armv7       sunxi               -              sunxi       sun7i:MARSBOARD_A20,SPL,SUNXI_EMAC,NO_AXP
+Marsboard_A20_debug          arm         armv7       sunxi               -              sunxi       sun7i:MARSBOARD_A20,SPL,SUNXI_EMAC,NO_AXP,SYS_SECONDARY_ON
 Cubieboard                   arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_FEL               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL_FEL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_512               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD_512,SPL,SUNXI_EMAC,STATUSLED=244

--- a/boards.cfg
+++ b/boards.cfg
@@ -351,6 +351,7 @@ Coby_MID7042                 arm         armv7       sunxi               -      
 Coby_MID8042                 arm         armv7       sunxi               -              sunxi       sun4i:COBY_MID8042,SPL
 Coby_MID9742                 arm         armv7       sunxi               -              sunxi       sun4i:COBY_MID9742,SPL
 Marsboard_A10                arm         armv7       sunxi               -              sunxi       sun4i:MARSBOARD_A10,SPL,SUNXI_EMAC,NO_AXP
+Marsboard_A20                arm         armv7       sunxi               -              sunxi       sun7i:MARSBOARD_A20,SPL,SUNXI_EMAC,NO_AXP
 Cubieboard                   arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_FEL               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD,SPL_FEL,SUNXI_EMAC,STATUSLED=244
 Cubieboard_512               arm         armv7       sunxi               -              sunxi       sun4i:CUBIEBOARD_512,SPL,SUNXI_EMAC,STATUSLED=244

--- a/common/cmd_elf.c
+++ b/common/cmd_elf.c
@@ -35,8 +35,8 @@ unsigned long do_bootelf_exec(ulong (*entry)(int, char * const[]),
 	unsigned long ret;
 
 	/*
-	 * QNX images require the data cache is disabled.
-	 * Data cache is already flushed, so just turn it off.
+	 * QNX and other kernels require the data cache is disabled.  Data cache
+	 * is already flushed, so just turn it off.
 	 */
 	int dcache = dcache_status();
 	if (dcache)
@@ -57,7 +57,7 @@ unsigned long do_bootelf_exec(ulong (*entry)(int, char * const[]),
 /* ======================================================================
  * Determine if a valid ELF image exists at the given memory location.
  * First looks at the ELF header magic field, the makes sure that it is
- * executable and makes sure that it is for a PowerPC.
+ * executable and makes sure that it is for a valid architecture.
  * ====================================================================== */
 int valid_elf_image(unsigned long addr)
 {
@@ -76,8 +76,13 @@ int valid_elf_image(unsigned long addr)
 		printf("## Not a 32-bit elf image at address 0x%08lx\n", addr);
 		return 0;
 	}
-
-#if 0
+#if defined(CONFIG_ARM)
+	if (ehdr->e_machine != EM_ARM) {
+		printf("## Not an ARM elf image at address 0x%08lx\n", addr);
+		return 0;
+	}
+#endif
+#if defined(CONFIG_PPC)
 	if (ehdr->e_machine != EM_PPC) {
 		printf("## Not a PowerPC elf image at address 0x%08lx\n", addr);
 		return 0;

--- a/include/configs/sun4i.h
+++ b/include/configs/sun4i.h
@@ -30,7 +30,7 @@
  */
 #define CONFIG_SUN4I		/* sun4i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun4i#"
+#define CONFIG_SYS_PROMPT		"sun4i# "
 #define CONFIG_MACH_TYPE		4104
 
 /*

--- a/include/configs/sun5i.h
+++ b/include/configs/sun5i.h
@@ -30,7 +30,7 @@
  */
 #define CONFIG_SUN5I		/* sun5i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun5i#"
+#define CONFIG_SYS_PROMPT		"sun5i# "
 #define CONFIG_MACH_TYPE		4138
 
 /*

--- a/include/configs/sun7i.h
+++ b/include/configs/sun7i.h
@@ -31,7 +31,7 @@
  */
 #define CONFIG_SUN7I		/* sun7i SoC generation */
 
-#define CONFIG_SYS_PROMPT		"sun7i#"
+#define CONFIG_SYS_PROMPT		"sun7i# "
 #define CONFIG_MACH_TYPE		4283
 
 /*

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -37,6 +37,7 @@
 
 #include <asm/arch/cpu.h>	/* get chip and board defs */
 
+/* Put u-boot at 160MB from start of SDRAM */
 #define CONFIG_SYS_TEXT_BASE		0x4a000000
 
 /*
@@ -188,6 +189,7 @@
 	"extraargs=\0" \
 	"loglevel=8\0" \
 	"scriptaddr=0x44000000\0" \
+	"loadaddr=0x4b000000\0" \
 	"device=mmc\0" \
 	"partition=0:1\0" \
 	"setargs=" \
@@ -224,19 +226,19 @@
 	    " && " \
 	    "ext2load $device $partition 0x43000000 ${bootpath}script.bin" \
 	    " && " \
-	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
+	    "ext2load $device $partition ${loadaddr} ${bootpath}${kernel}" \
 	  ";then true; elif " \
 	    "bootpath=/" \
 	    " && " \
 	    "fatload $device $partition 0x43000000 script.bin" \
 	    " && " \
-	    "fatload $device $partition 0x48000000 ${kernel}" \
+	    "fatload $device $partition ${loadaddr} ${kernel}" \
 	  ";then true; elif " \
 	    "bootpath=/" \
 	    " && " \
 	    "ext2load $device $partition 0x43000000 ${bootpath}script.bin" \
 	    " && " \
-	    "ext2load $device $partition 0x48000000 ${bootpath}${kernel}" \
+	    "ext2load $device $partition ${loadaddr} ${bootpath}${kernel}" \
 	  ";then true; else "\
 	    "false" \
 	  ";fi" \
@@ -248,7 +250,7 @@
 	  " && " \
 	  RESET_WATCHDOG \
 	  " && " \
-	  "bootm 0x48000000" \
+	  "bootm ${loadaddr}" \
 	  "\0" \
 	"boot_ram=" \
 	  "saved_stdout=$stdout;setenv stdout nc;"\
@@ -277,7 +279,6 @@
 #define CONFIG_FAT_WRITE	/* enable write access */
 #define CONFIG_CMD_EXT2		/* with this we can access ext2 bootfs */
 #define CONFIG_CMD_EXT4		/* with this we can access ext4 bootfs */
-#define CONFIG_CMD_ZFS		/* with this we can access ZFS bootfs */
 
 #define CONFIG_SPL_FRAMEWORK
 #define CONFIG_SPL_LIBCOMMON_SUPPORT
@@ -423,6 +424,7 @@
 #define CONFIG_BOOTP_MAY_FAIL
 #define CONFIG_BOOTP_SERVERIP
 #define CONFIG_BOOTP_DHCP_REQUEST_DELAY		50000
+#define CONFIG_CMD_ELF
 #endif
 
 #if !defined CONFIG_ENV_IS_IN_MMC && \

--- a/tools/mksunxiboot.README
+++ b/tools/mksunxiboot.README
@@ -1,4 +1,4 @@
-This program make a arm binary file can be loaded by Allwinner A10 and releated
+This program make a arm binary file can be loaded by Allwinner A10 and related
 chips from storage media such as nand and mmc.
 
 More information about A10 boot, please refer to


### PR DESCRIPTION
This is a follow-on from the marsboard a20 changes from the previous pull-request.
Note: The diff includes those changes.

This adds:
- Code to power-on and keep the second A20 core in a waiting loop.
- This is important for debugging - JTAG tools require all cores you wish to debug to be powered-on.
- Modified smp-boot API (need to update Linux - not done yet).
  - Check if CPU1 is held in reset, if not, just set the boot_addr and perform a "sev" or a write of (2) to cpucfg->event_in
  - This has been tested with a different (non-Linux) SMP kernel
