### PR TITLE
fixed awk error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -852,7 +852,7 @@ unconfig:
 sinclude $(obj).boards.depend
 $(obj).boards.depend:	boards.cfg
 	@awk '(NF && $$1 !~ /^#/) { print $$7 ": " $$7 "_config; $$(MAKE)" }' $< > $@
-	@awk '(NF && $$1 !~ /^#/ && tolower($$7) != $$7) { print tolower($$7 ": " $$7 "_config); $$(MAKE)" }' $< >> $@
+	@awk '(NF && $$1 !~ /^#/ && tolower($$7) != $$7) { print tolower($$7) ": " tolower($$7) "_config); $$(MAKE)" }' $< >> $@
 
 #
 # Functions to generate common board directory names


### PR DESCRIPTION
`tolower` throws an error if used with multiple arguments. This change should fix that.
