### PR TITLE
sunxi-mmc: sun8i has its fifo at a different address

### DIFF
--- a/drivers/mmc/sunxi_mmc.c
+++ b/drivers/mmc/sunxi_mmc.c
@@ -57,7 +57,7 @@ static int mmc_resource_init(int sdc_no)
 		printf("Wrong mmc number %d\n", sdc_no);
 		return -1;
 	}
-#ifdef CONFIG_SUN6I
+#if defined(CONFIG_SUN6I) || defined(CONFIG_SUN8I)
 	mmchost->database = (unsigned int)mmchost->reg + 0x200;
 #else
 	mmchost->database = (unsigned int)mmchost->reg + 0x100;


### PR DESCRIPTION
This fixes the mmc code no longer working on sun8i after the changes to
stop using dma, like sun6i.

Signed-off-by: Chen-Yu Tsai wens@csie.org
Acked-by: Hans de Goede hdegoede@redhat.com
