### PR TITLE
gpio: sunxi: Add compatible string for H5 PIO

### DIFF
--- a/drivers/gpio/sunxi_gpio.c
+++ b/drivers/gpio/sunxi_gpio.c
@@ -345,6 +345,7 @@ static const struct udevice_id sunxi_gpio_ids[] = {
 	ID("allwinner,sun4i-a10-pinctrl",	a_all),
 	ID("allwinner,sun5i-a10s-pinctrl",	a_all),
 	ID("allwinner,sun5i-a13-pinctrl",	a_all),
+	ID("allwinner,sun50i-h5-pinctrl",	a_all),
 	ID("allwinner,sun6i-a31-pinctrl",	a_all),
 	ID("allwinner,sun6i-a31s-pinctrl",	a_all),
 	ID("allwinner,sun7i-a20-pinctrl",	a_all),


### PR DESCRIPTION
Due to the changes in https://github.com/linux-sunxi/u-boot-sunxi/commit/8faac0941cd409c6ff3738fbf658de2296f48e9a, allwinner,sun50i-h5-pinctrl needs to be defined otherwise PIO does not work on H5 based boards.

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>